### PR TITLE
Notes performance

### DIFF
--- a/FourSix Coffee Timer.xcodeproj/project.pbxproj
+++ b/FourSix Coffee Timer.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		6529E11D249FF2E30093FAE1 /* howto.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 6529E11C249FF2E30093FAE1 /* howto.rtf */; };
 		652C4A5D24AAA77600857883 /* AcknowledgementsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652C4A5C24AAA77600857883 /* AcknowledgementsVC.swift */; };
 		652C95E624B28E3B00B471C8 /* SettingsVC.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 652C95E424B28E3B00B471C8 /* SettingsVC.storyboard */; };
+		652DC7E92645C29B003CDAA7 /* RatingStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652DC7E82645C29B003CDAA7 /* RatingStackView.swift */; };
 		65315ADE249ADB4D00994E28 /* Clean+DoubleFloat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65315ADD249ADB4D00994E28 /* Clean+DoubleFloat.swift */; };
 		6531720A24A6B06F00709062 /* RecipeVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6531720924A6B06F00709062 /* RecipeVC.swift */; };
 		6531720E24A6B4DB00709062 /* RoundButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6531720D24A6B4DB00709062 /* RoundButton.swift */; };
@@ -171,6 +172,7 @@
 		6529E11C249FF2E30093FAE1 /* howto.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; path = howto.rtf; sourceTree = "<group>"; };
 		652C4A5C24AAA77600857883 /* AcknowledgementsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementsVC.swift; sourceTree = "<group>"; };
 		652C95E524B28E3B00B471C8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/SettingsVC.storyboard; sourceTree = "<group>"; };
+		652DC7E82645C29B003CDAA7 /* RatingStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingStackView.swift; sourceTree = "<group>"; };
 		65315ADD249ADB4D00994E28 /* Clean+DoubleFloat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Clean+DoubleFloat.swift"; sourceTree = "<group>"; };
 		6531720924A6B06F00709062 /* RecipeVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeVC.swift; sourceTree = "<group>"; };
 		6531720D24A6B4DB00709062 /* RoundButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundButton.swift; sourceTree = "<group>"; };
@@ -365,6 +367,7 @@
 			isa = PBXGroup;
 			children = (
 				653E631A26095B6E00BA32BF /* RatingControl.swift */,
+				652DC7E82645C29B003CDAA7 /* RatingStackView.swift */,
 				6536F2732602BE6000E2DF28 /* NotesTable */,
 				6536F2762602BE7000E2DF28 /* NoteDetails */,
 				65DD15DB261E6B8200EB000E /* CoffeePicker */,
@@ -937,6 +940,7 @@
 				6542DDFA25D858AB0067C704 /* SettingsNavigationController.swift in Sources */,
 				653DBF6625F2F31A00AE7D9E /* Constants.swift in Sources */,
 				65D5DE8B260D38B800353385 /* CoffeeMO+CoreDataClass.swift in Sources */,
+				652DC7E92645C29B003CDAA7 /* RatingStackView.swift in Sources */,
 				65A2775425FFE88F0093B0B9 /* AlertHelper.swift in Sources */,
 				653E631B26095B6E00BA32BF /* RatingControl.swift in Sources */,
 				65BE8AA025D7231A007177B8 /* BrewCoordinator.swift in Sources */,

--- a/FourSix Coffee Timer/Controllers/Notes/NoteDetails/CoffeePickerView.swift
+++ b/FourSix Coffee Timer/Controllers/Notes/NoteDetails/CoffeePickerView.swift
@@ -31,14 +31,13 @@ class CoffeePickerView: RoundedView {
         }
     }
     
-    var isEditing: Bool = false
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        commonInit()
+    }
     
-    func setEditing(_ editing: Bool) {
-        isEditing = editing
-        
-        addCoffeeLabel.text = isEditing ? "Pick Coffee" : "None Selected"
-        chevronImage.isHidden = !isEditing
-        addCoffeeImage.isHidden = !isEditing
+    private func commonInit() {
+        showNewCoffeePicker(true)
     }
     
     private func showNewCoffeePicker(_ shouldShow: Bool) {

--- a/FourSix Coffee Timer/Controllers/Notes/NoteDetails/NoteDetailsVC.storyboard
+++ b/FourSix Coffee Timer/Controllers/Notes/NoteDetails/NoteDetailsVC.storyboard
@@ -55,9 +55,6 @@
                                                                     <userDefinedRuntimeAttribute type="number" keyPath="starCount">
                                                                         <integer key="value" value="5"/>
                                                                     </userDefinedRuntimeAttribute>
-                                                                    <userDefinedRuntimeAttribute type="color" keyPath="disabledColor">
-                                                                        <color key="value" systemColor="labelColor"/>
-                                                                    </userDefinedRuntimeAttribute>
                                                                 </userDefinedRuntimeAttributes>
                                                             </stackView>
                                                         </subviews>
@@ -426,7 +423,7 @@
                                                                                     <constraint firstAttribute="height" constant="20" id="8Eq-Bx-iOw"/>
                                                                                 </constraints>
                                                                             </imageView>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="None selected" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4s9-M6-BVZ">
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Pick Coffee" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4s9-M6-BVZ">
                                                                                 <rect key="frame" x="28" y="1.5" width="264" height="17"/>
                                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                                                 <nil key="highlightedColor"/>
@@ -498,10 +495,10 @@
                                                         </connections>
                                                     </view>
                                                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j5f-c1-40m" customClass="DatePickerView" customModule="FourSix" customModuleProvider="target">
-                                                        <rect key="frame" x="7" y="1042" width="340" height="350"/>
+                                                        <rect key="frame" x="0.0" y="1042" width="354" height="350"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wMT-Zb-cp9">
-                                                                <rect key="frame" x="16" y="0.0" width="308" height="45"/>
+                                                                <rect key="frame" x="16" y="0.0" width="322" height="45"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Roast Date" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vHU-rz-Cxx">
                                                                         <rect key="frame" x="0.0" y="14" width="71" height="17"/>
@@ -510,7 +507,7 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O9y-wh-HWR">
-                                                                        <rect key="frame" x="154" y="14" width="154" height="17"/>
+                                                                        <rect key="frame" x="161" y="14" width="161" height="17"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -528,24 +525,14 @@
                                                                     <constraint firstItem="O9y-wh-HWR" firstAttribute="top" secondItem="wMT-Zb-cp9" secondAttribute="top" constant="14" id="yCv-k5-iRw"/>
                                                                 </constraints>
                                                             </view>
-                                                            <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" translatesAutoresizingMaskIntoConstraints="NO" id="7js-a7-cUE">
-                                                                <rect key="frame" x="10" y="53" width="320" height="216"/>
-                                                                <color key="tintColor" name="Accent"/>
-                                                                <connections>
-                                                                    <action selector="didChangeDate:" destination="j5f-c1-40m" eventType="valueChanged" id="7Ur-QQ-3Wz"/>
-                                                                </connections>
-                                                            </datePicker>
                                                         </subviews>
                                                         <color key="backgroundColor" name="Background"/>
                                                         <constraints>
                                                             <constraint firstAttribute="trailing" secondItem="wMT-Zb-cp9" secondAttribute="trailing" constant="16" id="62g-xK-far"/>
-                                                            <constraint firstItem="7js-a7-cUE" firstAttribute="leading" secondItem="j5f-c1-40m" secondAttribute="leading" constant="10" id="64b-kR-rwn"/>
                                                             <constraint firstItem="wMT-Zb-cp9" firstAttribute="leading" secondItem="j5f-c1-40m" secondAttribute="leading" constant="16" id="7qL-Xl-db3"/>
-                                                            <constraint firstAttribute="trailing" secondItem="7js-a7-cUE" secondAttribute="trailing" constant="10" id="AAS-Y1-K11"/>
                                                             <constraint firstItem="wMT-Zb-cp9" firstAttribute="top" secondItem="j5f-c1-40m" secondAttribute="top" id="HNh-tx-LAg"/>
                                                             <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="wMT-Zb-cp9" secondAttribute="bottom" id="HnY-DE-th8"/>
                                                             <constraint firstAttribute="height" constant="350" id="PyJ-7Y-3Rv"/>
-                                                            <constraint firstItem="7js-a7-cUE" firstAttribute="top" secondItem="wMT-Zb-cp9" secondAttribute="bottom" constant="8" id="T07-da-t1n"/>
                                                         </constraints>
                                                         <userDefinedRuntimeAttributes>
                                                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
@@ -553,7 +540,6 @@
                                                             </userDefinedRuntimeAttribute>
                                                         </userDefinedRuntimeAttributes>
                                                         <connections>
-                                                            <outlet property="datePicker" destination="7js-a7-cUE" id="tbv-Dl-gl7"/>
                                                             <outlet property="datePickerHeight" destination="PyJ-7Y-3Rv" id="JI7-vf-UbW"/>
                                                             <outlet property="labelsContainerView" destination="wMT-Zb-cp9" id="mUo-5s-r4N"/>
                                                             <outlet property="roastDateLabel" destination="O9y-wh-HWR" id="kOH-bW-H7f"/>
@@ -587,10 +573,12 @@
                                                     <constraint firstItem="AWr-eY-C2J" firstAttribute="leading" secondItem="a4b-Nf-Lj6" secondAttribute="leading" id="CDq-Ph-SSm"/>
                                                     <constraint firstItem="jB1-kz-DLK" firstAttribute="leading" secondItem="a4b-Nf-Lj6" secondAttribute="leading" id="KTI-hd-UNh"/>
                                                     <constraint firstAttribute="trailing" secondItem="jB1-kz-DLK" secondAttribute="trailing" id="QvL-43-SO1"/>
+                                                    <constraint firstAttribute="trailing" secondItem="j5f-c1-40m" secondAttribute="trailing" id="VZN-8x-dbF"/>
                                                     <constraint firstItem="rb7-ut-1ac" firstAttribute="leading" secondItem="6Ld-E6-NmD" secondAttribute="leading" id="Xle-cS-bD3"/>
                                                     <constraint firstAttribute="trailing" secondItem="g44-jm-k1p" secondAttribute="trailing" id="ahY-3J-Q1n"/>
                                                     <constraint firstItem="O9y-wh-HWR" firstAttribute="leading" secondItem="rb7-ut-1ac" secondAttribute="leading" id="cbY-wL-baS"/>
                                                     <constraint firstItem="g44-jm-k1p" firstAttribute="leading" secondItem="a4b-Nf-Lj6" secondAttribute="leading" id="dKY-fj-kEg"/>
+                                                    <constraint firstItem="j5f-c1-40m" firstAttribute="leading" secondItem="a4b-Nf-Lj6" secondAttribute="leading" id="j39-Uc-ZKk"/>
                                                     <constraint firstItem="EXS-qe-jrf" firstAttribute="leading" secondItem="a4b-Nf-Lj6" secondAttribute="leading" id="m7M-un-hM4"/>
                                                     <constraint firstAttribute="trailing" secondItem="EXS-qe-jrf" secondAttribute="trailing" id="ntc-CN-8dq"/>
                                                     <constraint firstAttribute="trailing" secondItem="AWr-eY-C2J" secondAttribute="trailing" id="oRk-xD-qzm"/>

--- a/FourSix Coffee Timer/Controllers/Notes/NoteDetails/NotesTextView.swift
+++ b/FourSix Coffee Timer/Controllers/Notes/NoteDetails/NotesTextView.swift
@@ -9,17 +9,6 @@
 import UIKit
 
 class NotesTextView: UITextView {
-    private var editMode: Bool = false {
-        didSet {
-            layer.backgroundColor = editMode ? editOnColor?.cgColor : editOffColor?.cgColor
-            layer.borderWidth = editMode ? 0.5 : 0
-            isEditable = editMode
-        }
-    }
-    
-    private var editOnColor: UIColor? = UIColor(named: AssetsColor.background.rawValue)
-    private var editOffColor: UIColor? = UIColor(named: AssetsColor.background.rawValue)
-    
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
         commonInit()
@@ -33,27 +22,11 @@ class NotesTextView: UITextView {
     private func commonInit() {
         layer.cornerRadius = 5
         layer.borderColor = UIColor.gray.withAlphaComponent(0.5).cgColor
-        layer.borderWidth = 0
+        layer.borderWidth = 0.5
         clipsToBounds = true
-        layer.backgroundColor = editOffColor?.cgColor
-        isEditable = false
+        layer.backgroundColor = UIColor(named: AssetsColor.background.rawValue)?.cgColor
+        isEditable = true
         
         textContainerInset = UIEdgeInsets(top: 15, left: 8, bottom: 15, right: 8)
-    }
-    
-    func setToEditMode(_ shouldSetToEdit: Bool) {
-        guard editMode != shouldSetToEdit else { return }
-        
-        editMode = shouldSetToEdit
-    }
-    
-    // Fix colors when switching between System Light and Dark Mode
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        updateColors()
-    }
-    
-    private func updateColors() {
-        layer.backgroundColor = editMode ? editOnColor?.cgColor : editOffColor?.cgColor
     }
 }

--- a/FourSix Coffee Timer/Controllers/Notes/NotesTable/NoteCell.swift
+++ b/FourSix Coffee Timer/Controllers/Notes/NotesTable/NoteCell.swift
@@ -15,7 +15,7 @@ class NoteCell: UITableViewCell {
     @IBOutlet weak var recipeLabel: UILabel!
     @IBOutlet weak var coffeeLabel: UILabel!
     @IBOutlet weak var waterLabel: UILabel!
-    @IBOutlet weak var ratingStackView: RatingControl!
+    @IBOutlet weak var ratingStackView: RatingStackView!
     
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/FourSix Coffee Timer/Controllers/Notes/NotesTable/NotesCoordinator.swift
+++ b/FourSix Coffee Timer/Controllers/Notes/NotesTable/NotesCoordinator.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import CoreData
 
 class NotesCoordinator: NSObject, Coordinator, UINavigationControllerDelegate {
     var childCoordinators: [Coordinator] = []

--- a/FourSix Coffee Timer/Controllers/Notes/NotesTable/NotesVC.storyboard
+++ b/FourSix Coffee Timer/Controllers/Notes/NotesTable/NotesVC.storyboard
@@ -35,7 +35,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="YEE-RY-QbS">
-                                                    <rect key="frame" x="136" y="19" width="147" height="61"/>
+                                                    <rect key="frame" x="136" y="3" width="147" height="93"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Balance &amp; Strength" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MOS-1t-jMt">
                                                             <rect key="frame" x="0.0" y="0.0" width="147" height="20.5"/>
@@ -53,6 +53,7 @@
                                                                         <constraint firstAttribute="height" constant="12" id="1Io-t8-7yx"/>
                                                                         <constraint firstAttribute="width" constant="15" id="i2M-nc-0l0"/>
                                                                     </constraints>
+                                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                                                                 </imageView>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="20g" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R2j-Yc-uAK">
                                                                     <rect key="frame" x="20" y="0.0" width="30.5" height="20.5"/>
@@ -67,6 +68,7 @@
                                                                         <constraint firstAttribute="width" constant="15" id="lzl-K4-kiC"/>
                                                                         <constraint firstAttribute="height" constant="12" id="tpG-4Y-NzG"/>
                                                                     </constraints>
+                                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                                                                 </imageView>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="300g" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FkH-eI-F80">
                                                                     <rect key="frame" x="75.5" y="0.0" width="41" height="20.5"/>
@@ -76,14 +78,17 @@
                                                                 </label>
                                                             </subviews>
                                                         </stackView>
-                                                        <stackView opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="baa-VQ-DhJ" customClass="RatingControl" customModule="FourSix" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="43" width="98" height="18"/>
+                                                        <stackView opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="baa-VQ-DhJ" customClass="RatingStackView" customModule="FourSix" customModuleProvider="target">
+                                                            <rect key="frame" x="0.0" y="43" width="98" height="50"/>
                                                             <userDefinedRuntimeAttributes>
                                                                 <userDefinedRuntimeAttribute type="size" keyPath="starSize">
                                                                     <size key="value" width="18" height="18"/>
                                                                 </userDefinedRuntimeAttribute>
-                                                                <userDefinedRuntimeAttribute type="color" keyPath="disabledColor">
+                                                                <userDefinedRuntimeAttribute type="color" keyPath="color">
                                                                     <color key="value" name="Accent"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="starCount">
+                                                                    <integer key="value" value="5"/>
                                                                 </userDefinedRuntimeAttribute>
                                                             </userDefinedRuntimeAttributes>
                                                         </stackView>

--- a/FourSix Coffee Timer/Controllers/Notes/RatingControl.swift
+++ b/FourSix Coffee Timer/Controllers/Notes/RatingControl.swift
@@ -48,7 +48,7 @@ class RatingControl: UIStackView {
         }
     }
     
-    private var editMode: Bool = false {
+    private var editMode: Bool = true {
         didSet {
             for button in ratingButtons {
                 button.tintColor = editMode ? enabledColor : disabledColor
@@ -79,7 +79,7 @@ class RatingControl: UIStackView {
         for index in 0..<starCount {
             let button = UIButton()
             
-            button.tintColor = disabledColor
+            button.tintColor = enabledColor
             
             button.setImage(offImage, for: .normal)
             button.setImage(onImage, for: .selected)

--- a/FourSix Coffee Timer/Controllers/Notes/RatingStackView.swift
+++ b/FourSix Coffee Timer/Controllers/Notes/RatingStackView.swift
@@ -1,0 +1,81 @@
+//
+//  RatingStackView.swift
+//  FourSix Coffee Timer
+//
+//  Created by Jon Duenas on 5/7/21.
+//  Copyright © 2021 Jon Duenas. All rights reserved.
+//
+
+import UIKit
+
+class RatingStackView: UIStackView {
+    @IBInspectable var starSize: CGSize = CGSize(width: 44.0, height: 44.0) {
+        didSet {
+            setupImages()
+        }
+    }
+    
+    @IBInspectable var starCount: Int = 5 {
+        didSet {
+            setupImages()
+        }
+    }
+    
+    var rating: Int = 0 {
+        didSet {
+            setupImages()
+        }
+    }
+    
+    private var ratingImages: [UIImageView] = []
+    private var offImage: UIImage? = UIImage(systemName: "star", withConfiguration: UIImage.SymbolConfiguration(pointSize: 30))
+    private var onImage: UIImage? = UIImage(systemName: "star.fill", withConfiguration: UIImage.SymbolConfiguration(pointSize: 30))
+    @IBInspectable var color: UIColor? = UIColor(named: AssetsColor.accent.rawValue) {
+        didSet {
+            setupImages()
+        }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupImages()
+    }
+    
+    required init(coder: NSCoder) {
+        super.init(coder: coder)
+        setupImages()
+    }
+    
+    private func setupImages() {
+        // Clear existing images
+        for image in ratingImages {
+            removeArrangedSubview(image)
+            image.removeFromSuperview()
+        }
+        
+        ratingImages.removeAll()
+        
+        let offCount = starCount - rating
+        
+        // Create new images
+        for _ in 0..<rating {
+            let imageView = createImageView(with: onImage)
+            addArrangedSubview(imageView)
+            ratingImages.append(imageView)
+        }
+        
+        for _ in 0..<offCount {
+            let imageView = createImageView(with: offImage)
+            addArrangedSubview(imageView)
+            ratingImages.append(imageView)
+        }
+    }
+    
+    private func createImageView(with image: UIImage?) -> UIImageView {
+        let imageView = UIImageView(image: image)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.heightAnchor.constraint(equalToConstant: starSize.height).isActive = true
+        imageView.widthAnchor.constraint(equalToConstant: starSize.width).isActive = true
+        return imageView
+    }
+}

--- a/FourSix Coffee Timer/Controllers/Notes/RatingStackView.swift
+++ b/FourSix Coffee Timer/Controllers/Notes/RatingStackView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class RatingStackView: UIStackView {
-    @IBInspectable var starSize: CGSize = CGSize(width: 44.0, height: 44.0) {
+    @IBInspectable var starSize: CGSize = CGSize(width: 18, height: 18) {
         didSet {
             setupImages()
         }
@@ -28,8 +28,8 @@ class RatingStackView: UIStackView {
     }
     
     private var ratingImages: [UIImageView] = []
-    private var offImage: UIImage? = UIImage(systemName: "star", withConfiguration: UIImage.SymbolConfiguration(pointSize: 30))
-    private var onImage: UIImage? = UIImage(systemName: "star.fill", withConfiguration: UIImage.SymbolConfiguration(pointSize: 30))
+    private var offImage: UIImage? = UIImage(systemName: "star", withConfiguration: UIImage.SymbolConfiguration(scale: .small))
+    private var onImage: UIImage? = UIImage(systemName: "star.fill", withConfiguration: UIImage.SymbolConfiguration(scale: .small))
     @IBInspectable var color: UIColor? = UIColor(named: AssetsColor.accent.rawValue) {
         didSet {
             setupImages()


### PR DESCRIPTION
Fix issues with performance when showing the Notes list and Note details view.

- Remove UIDatePicker from Storyboard initialization causing performance lag on the main thread when loading the Note Details view. Initialize it programmatically only when the user taps to show it.
- Add RatingStackView separate from RatingControl that only shows images and doesn't use buttons or allow any control.
- Remove unnecessary "Edit Mode" from Note Details and its elements.