### PR TITLE
IAPManager refactor

### DIFF
--- a/FourSix Coffee Timer/Controllers/Settings/Tip Jar/TipJarVC.swift
+++ b/FourSix Coffee Timer/Controllers/Settings/Tip Jar/TipJarVC.swift
@@ -70,7 +70,7 @@ class TipJarVC: UIViewController, Storyboarded {
         
         let tipPackage = IAPManager.shared.tipPackages[sender.tag]
         
-        IAPManager.shared.purchase(package: tipPackage) { [weak self] succeeded, error in
+        IAPManager.shared.purchase(package: tipPackage, entitlementID: nil) { [weak self] succeeded, error in
             guard let self = self else { return }
             
             self.setState(loading: false, button: sender, animated: true)

--- a/FourSix Coffee Timer/Helpers/IAPManager.swift
+++ b/FourSix Coffee Timer/Helpers/IAPManager.swift
@@ -124,7 +124,7 @@ class IAPManager: NSObject {
         }
     }
     
-    func purchase(package: Purchases.Package, purchaseSucceeded: @escaping (Bool, String?) -> Void) {
+    func purchase(package: Purchases.Package, entitlementID: String?, purchaseSucceeded: @escaping (Bool, String?) -> Void) {
         if Purchases.canMakePayments() {
             Purchases.shared.purchasePackage(package) { (_, purchaserInfo, error, userCancelled) in
                 if let error = error as NSError? {
@@ -152,7 +152,17 @@ class IAPManager: NSObject {
                         purchaseSucceeded(false, nil)
                     }
                 } else {
-                    // Successful purchase
+                    // Successful purchase, double check if user now has active entitlement
+                    if let entitlementID = entitlementID {
+                        let activeEntitlement = purchaserInfo?.entitlements[entitlementID]?.isActive
+                        if activeEntitlement == true {
+                            purchaseSucceeded(true, nil)
+                        } else {
+                            purchaseSucceeded(false, "Unknown error. Please contact developer.")
+                        }
+                    }
+                    
+                    // If no check is needed, like for tips, then just mark as successful
                     purchaseSucceeded(true, nil)
                 }
             }

--- a/FourSix Coffee Timer/Helpers/IAPManager.swift
+++ b/FourSix Coffee Timer/Helpers/IAPManager.swift
@@ -126,8 +126,7 @@ class IAPManager: NSObject {
     
     func purchase(package: Purchases.Package, purchaseSucceeded: @escaping (Bool, String?) -> Void) {
         if Purchases.canMakePayments() {
-            Purchases.shared.purchasePackage(package) { [weak self] (_, purchaserInfo, error, userCancelled) in
-                guard let self = self else { return }
+            Purchases.shared.purchasePackage(package) { (_, purchaserInfo, error, userCancelled) in
                 if let error = error as NSError? {
                     if !userCancelled {
                         // Log error details
@@ -149,15 +148,12 @@ class IAPManager: NSObject {
                             purchaseSucceeded(false, errMessage)
                         }
                     } else {
+                        // User cancelled
                         purchaseSucceeded(false, nil)
                     }
                 } else {
                     // Successful purchase
-                    if purchaserInfo?.entitlements[self.entitlementID]?.isActive == true {
-                        purchaseSucceeded(true, nil)
-                    } else {
-                        purchaseSucceeded(false, nil)
-                    }
+                    purchaseSucceeded(true, nil)
                 }
             }
         } else {


### PR DESCRIPTION
- Add optional `entitlementID` parameter to `purchase(package:purchaseSucceeded:)` method so it can be used for purchasing non-consumables that are not tied to entitlements, such as a tip.
- Change error message when purchase fails on PurchaseProVC.