### PR TITLE
Fix bug where toolbar would prematurely hide.

### DIFF
--- a/FourSix Coffee Timer/Controllers/Settings/About/WebViewVC.swift
+++ b/FourSix Coffee Timer/Controllers/Settings/About/WebViewVC.swift
@@ -49,14 +49,13 @@ class WebViewVC: UIViewController, WKNavigationDelegate {
         webView.load(urlString)
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
 
-        navigationController?.setToolbarHidden(true, animated: animated)
+        navigationController?.setToolbarHidden(false, animated: animated)
     }
 
     private func configureToolbar() {
-        navigationController?.setToolbarHidden(false, animated: false)
         navigationController?.toolbar.tintColor = UIColor(named: AssetsColor.accent.rawValue)
 
         let backButton = UIBarButtonItem(

--- a/FourSix Coffee Timer/Controllers/Settings/SettingsVC.swift
+++ b/FourSix Coffee Timer/Controllers/Settings/SettingsVC.swift
@@ -25,6 +25,12 @@ class SettingsVC: UIViewController, PaywallDelegate, Storyboarded {
         checkForProStatus()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        navigationController?.setToolbarHidden(true, animated: animated)
+    }
+
     private func initNavBar() {
         title = "Settings"
         navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "xmark"),


### PR DESCRIPTION
Fixes bug where the toolbar for the webview would prematurely hide in cases where the user may accidentally start to drag the entire view down to dismiss, triggering `viewWillDisappear` but then cancels it. 

Instead, the toolbar is set to hide on SettingsVC `viewDidAppear`, and then set to show on webview's `viewDidAppear` for visual animation consistency.