### PR TITLE
Use MFMailComposeViewController for "Send Feedback" in Settings

### DIFF
--- a/FourSix Coffee Timer/Constants.swift
+++ b/FourSix Coffee Timer/Constants.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 struct Constants {
+    static let emailAddress = "jon@foursixcoffeeapp.com"
     static let revenueCatAPIKey = "dDIhCeApJetzFIZVnXDjcLxLTPTjIoyr"
     static let productURL = URL(string: "https://apps.apple.com/app/id1519905670")!
     static let twitterURL = URL(string: "https://www.twitter.com/foursixcoffee")!

--- a/FourSix Coffee Timer/Controllers/Settings/SettingsCoordinator.swift
+++ b/FourSix Coffee Timer/Controllers/Settings/SettingsCoordinator.swift
@@ -7,8 +7,9 @@
 //
 
 import UIKit
+import MessageUI
 
-class SettingsCoordinator: Coordinator {
+class SettingsCoordinator: NSObject, Coordinator {
     var childCoordinators = [Coordinator]()
     weak var parentCoordinator: BrewCoordinator?
     var navigationController: UINavigationController
@@ -58,8 +59,30 @@ class SettingsCoordinator: Coordinator {
         pushVCWithNoDependencies(viewController: AcknowledgementsVC())
     }
 
+    func sendEmail() {
+        if MFMailComposeViewController.canSendMail() {
+            let mail = MFMailComposeViewController()
+            mail.mailComposeDelegate = self
+            mail.setToRecipients([Constants.emailAddress])
+            mail.setSubject("Feedback")
+
+            navigationController.present(mail, animated: true)
+        } else {
+            AlertHelper.showAlert(
+                title: "Error Creating Email",
+                message: "Please make sure you've setup email on your device. You can also simply send an email to jon@foursixcoffeeapp.com.",
+                on: navigationController)
+        }
+    }
+
     private func pushVCWithNoDependencies <T: Storyboarded>(viewController: T) where T: UIViewController {
         let vc = T.instantiate(fromStoryboardNamed: settingsStoryboardName)
         navigationController.pushViewController(vc, animated: true)
+    }
+}
+
+extension SettingsCoordinator: MFMailComposeViewControllerDelegate {
+    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        controller.dismiss(animated: true)
     }
 }

--- a/FourSix Coffee Timer/Controllers/Settings/SettingsVC.swift
+++ b/FourSix Coffee Timer/Controllers/Settings/SettingsVC.swift
@@ -70,17 +70,6 @@ class SettingsVC: UIViewController, PaywallDelegate, Storyboarded {
 
     // MARK: TableView Methods
 
-    fileprivate func sendFeedback() {
-        AlertHelper.showCancellableAlert(title: "Opening...",
-                                         message: "Sending you to Twitter to give feedback.",
-                                         confirmButtonTitle: "Open Twitter",
-                                         dismissButtonTitle: "Cancel",
-                                         on: self,
-                                         confirmHandler: { _ in
-                                            UIApplication.shared.open(Constants.twitterURL)
-                                         })
-    }
-
     fileprivate func rateInAppStore() {
         guard let writeReviewURL = Constants.reviewProductURL else { return }
         UIApplication.shared.open(writeReviewURL)
@@ -139,7 +128,7 @@ extension SettingsVC: UITableViewDelegate {
                 print("Go to website")
                 coordinator?.showLearnMore()
             case .feedback:
-                sendFeedback()
+                coordinator?.sendEmail()
             case .tipJar:
                 print("Show Tip Jar")
                 coordinator?.showTipJar()


### PR DESCRIPTION
Tapping "Send Feedback" in Settings uses SettingsCoordinator to show MFMailComposeViewController with preset strings in to: field and subject line. SettingsCoordinator is set as MFMailComposeViewControllerDelegate to handle didFinishWith result.