### PR TITLE
Notes paywall

### DIFF
--- a/FourSix Coffee Timer/Controllers/Notes/NoteDetails/NoteDetailsVC.swift
+++ b/FourSix Coffee Timer/Controllers/Notes/NoteDetails/NoteDetailsVC.swift
@@ -357,6 +357,15 @@ extension NoteDetailsVC: RatingControlDelegate {
         }
     }
 
+    func ratingControlShouldChangeRating(_ ratingControl: RatingControl) -> Bool {
+        if !userIsPro {
+            coordinator?.showProPaywall(delegate: self)
+            return false
+        } else {
+            return true
+        }
+    }
+
     func ratingControl(ratingControl: RatingControl, didChangeRating rating: Int) {
         updateNote(with: rating)
     }

--- a/FourSix Coffee Timer/Controllers/Notes/NoteDetails/NoteDetailsVC.swift
+++ b/FourSix Coffee Timer/Controllers/Notes/NoteDetails/NoteDetailsVC.swift
@@ -165,9 +165,13 @@ class NoteDetailsVC: UIViewController, Storyboarded {
     // MARK: Coffee Picker
 
     @objc private func didTapCoffeeView() {
-        guard let note = note else { return }
+        if userIsPro {
+            guard let note = note else { return }
 
-        coordinator?.showCoffeePicker(currentPicked: note.coffee, dataManager: dataManager, delegate: self)
+            coordinator?.showCoffeePicker(currentPicked: note.coffee, dataManager: dataManager, delegate: self)
+        } else {
+            coordinator?.showProPaywall(delegate: self)
+        }
     }
 
     // MARK: Temperature Unit Control

--- a/FourSix Coffee Timer/Controllers/Notes/RatingControl.swift
+++ b/FourSix Coffee Timer/Controllers/Notes/RatingControl.swift
@@ -11,6 +11,13 @@ import UIKit
 protocol RatingControlDelegate: AnyObject {
     func ratingControlShouldShowHint(ratingControl: RatingControl)
     func ratingControl(ratingControl: RatingControl, didChangeRating rating: Int)
+    func ratingControlShouldChangeRating(_ ratingControl: RatingControl) -> Bool
+}
+
+extension RatingControlDelegate {
+    func ratingControlShouldChangeRating(_ ratingControl: RatingControl) -> Bool {
+        return true
+    }
 }
 
 @IBDesignable
@@ -115,14 +122,18 @@ class RatingControl: UIStackView {
             return
         }
 
-        setRating(for: sender)
+        if delegate?.ratingControlShouldChangeRating(self) ?? true {
+            setRating(for: sender)
+        }
     }
 
     @objc private func ratingButtonLongTapped(sender: UILongPressGestureRecognizer) {
         guard sender.state == .began else { return }
         guard let button = sender.view as? UIButton else { return }
 
-        setRating(for: button)
+        if delegate?.ratingControlShouldChangeRating(self) ?? true {
+            setRating(for: button)
+        }
     }
 
     private func setRating(for button: UIButton) {


### PR DESCRIPTION
Implemented paywall for editing notes. User is given free access to the auto-generated log notes that show session stats. If they want to edit the note by adding a rating, coffee, or any other detail to the note, they will need to pay for Pro.

- Checks for user pro status on `viewDidLoad`.
- Uses native UITextField and UITextView delegate methods for `textFieldShouldBeginEditing` and `textViewShouldBeginEditing`.
- Implements `ratingControlShouldChangeRating` to RatingControlDelegate protocol that defaults to `true`.

Closes #18 