### PR TITLE
Add alerts for errors using WKNavigationDelegate methods.

### DIFF
--- a/FourSix Coffee Timer/Controllers/Settings/About/WebViewVC.swift
+++ b/FourSix Coffee Timer/Controllers/Settings/About/WebViewVC.swift
@@ -9,7 +9,7 @@
 import UIKit
 import WebKit
 
-class WebViewVC: UIViewController, WKNavigationDelegate {
+class WebViewVC: UIViewController {
     let webView = WKWebView()
     var progressBar: UIProgressView = {
         let progressView = UIProgressView(progressViewStyle: .default)
@@ -134,6 +134,20 @@ class WebViewVC: UIViewController, WKNavigationDelegate {
         } else {
             progressBar.isHidden = false
         }
+    }
+}
+
+extension WebViewVC: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        AlertHelper.showAlert(title: "Error",
+                              message: error.localizedDescription,
+                              on: self)
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        AlertHelper.showAlert(title: "Error Loading Webpage",
+                              message: error.localizedDescription,
+                              on: self)
     }
 }
 


### PR DESCRIPTION
Shows error alerts when there was an issue loading the WKWebView request, such as when the user has no internet connection. This lets the user know there was an error rather than just showing a blank page with no alert.

Closes #30 