### PR TITLE
Add [weak self] to observe closures.

### DIFF
--- a/FourSix Coffee Timer/Controllers/Settings/About/WebViewVC.swift
+++ b/FourSix Coffee Timer/Controllers/Settings/About/WebViewVC.swift
@@ -91,14 +91,14 @@ class WebViewVC: UIViewController {
         backButton?.isEnabled = webView.canGoBack
         forwardButton?.isEnabled = webView.canGoForward
 
-        canGoBackObserver = webView.observe(\.canGoBack, options: [.new]) { _, change in
+        canGoBackObserver = webView.observe(\.canGoBack, options: [.new]) { [weak self] _, change in
             guard let newValue = change.newValue else { return }
-            self.backButton?.isEnabled = newValue
+            self?.backButton?.isEnabled = newValue
         }
 
-        canGoForwardObserver = webView.observe(\.canGoForward, options: [.new], changeHandler: { _, change in
+        canGoForwardObserver = webView.observe(\.canGoForward, options: [.new], changeHandler: { [weak self] _, change in
             guard let newValue = change.newValue else { return }
-            self.forwardButton?.isEnabled = newValue
+            self?.forwardButton?.isEnabled = newValue
         })
     }
 
@@ -110,8 +110,8 @@ class WebViewVC: UIViewController {
         progressBar.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 0).isActive = true
         progressBar.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 0).isActive = true
 
-        estimatedProgressObserver = webView.observe(\.estimatedProgress, options: [.new], changeHandler: { _, change in
-            self.updateProgressBar(change.newValue)
+        estimatedProgressObserver = webView.observe(\.estimatedProgress, options: [.new], changeHandler: { [weak self] _, change in
+            self?.updateProgressBar(change.newValue)
         })
     }
 


### PR DESCRIPTION
Closes #32 by adding `[weak self]` to the observer closures that were causing retain cycles and preventing the WebViewVC View Controller from deallocating.