### PR TITLE
Shorten descriptions.

### DIFF
--- a/FourSix Coffee Timer/Controllers/PurchasePro/Base.lproj/PurchaseProVC.storyboard
+++ b/FourSix Coffee Timer/Controllers/PurchasePro/Base.lproj/PurchaseProVC.storyboard
@@ -58,14 +58,14 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="XuM-ZY-dUV">
-                                        <rect key="frame" x="0.0" y="103" width="330" height="102.33333333333331"/>
+                                        <rect key="frame" x="0.0" y="114.33333333333331" width="330" height="79.666666666666686"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark.seal.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="sYD-At-qyN">
                                                 <rect key="frame" x="0.0" y="-0.66666666666666785" width="36" height="30.333333333333336"/>
                                                 <color key="tintColor" name="Accent"/>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Nr9-95-ayD">
-                                                <rect key="frame" x="52" y="0.0" width="278" height="102.33333333333333"/>
+                                                <rect key="frame" x="52" y="0.0" width="278" height="79.666666666666671"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Edit Notes" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="67G-j6-LFV">
                                                         <rect key="frame" x="0.0" y="0.0" width="278" height="29"/>
@@ -73,8 +73,8 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Give each brew a star rating and add additional details like grind size and water temperature." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="IHS-r0-gco">
-                                                        <rect key="frame" x="0.0" y="33.999999999999993" width="278" height="68.333333333333314"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Give each brew a star rating and add additional details." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="IHS-r0-gco">
+                                                        <rect key="frame" x="0.0" y="34" width="278" height="45.666666666666657"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="19"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -102,7 +102,7 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Save the different coffee beans you use, where they're from, and quickly add to future Notes." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="fbi-kp-QKu">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Save the different coffee beans you use and quickly add to Notes." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="fbi-kp-QKu">
                                                         <rect key="frame" x="0.0" y="34.333333333333364" width="278" height="68.333333333333314"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="19"/>
                                                         <nil key="textColor"/>


### PR DESCRIPTION
Longer descriptions made the view look too busy. Shortened them to give more breathing room and simplify.