### PR TITLE
Resolve bug where status bar style would be set incorrectly

### DIFF
--- a/FourSix Coffee Timer/Controllers/Brew/Timer/TimerNavigationController.swift
+++ b/FourSix Coffee Timer/Controllers/Brew/Timer/TimerNavigationController.swift
@@ -13,15 +13,13 @@ class TimerNavigationController: UINavigationController {
     var darkBackground: Bool = false
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        if darkBackground {
-            return .lightContent
-        } else {
-            return .darkContent
-        }
+        return darkBackground ? .lightContent : .darkContent
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        NotificationCenter.default.addObserver(self, selector: #selector(didActivate), name: UIScene.didActivateNotification, object: nil)
 
         navigationBar.isTranslucent = false
         navigationBar.barTintColor = UIColor(named: AssetsColor.background.rawValue)
@@ -33,6 +31,21 @@ class TimerNavigationController: UINavigationController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        darkBackground = traitCollection.userInterfaceStyle == .dark
+        // Makes sure app is active before continuing
+        //      iOS takes screenshots of both dark and light mode when entering background, which
+        //      calls traitCollectionDidChange twice. This guard ensures the rest of the method only
+        //      executes when app is currently active.
+        guard UIApplication.shared.applicationState == .active else { return }
+
+        if previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
+            // TimerVC is the only view controller that needs to change status bar style
+            guard self.visibleViewController as? TimerVC != nil else { return }
+
+            darkBackground = traitCollection.userInterfaceStyle == .dark
+        }
+    }
+
+    @objc func didActivate() {
+        setNeedsStatusBarAppearanceUpdate()
     }
 }


### PR DESCRIPTION
Status bar was being set incorrectly after app would enter background for TimerNavigationController. For the TimerVC when in light mode, exiting and returning to app would set status bar to white. For the NoteDetailsVC for a new note, it would set it to dark.

**Fix**

- Set TimerNavigationController to observe when scene activates, then call `setNeedsStatusBarAppearanceUpdate()`. Fixes issue with TimerVC.
- Add guard to ensure app is currently active and not in background when `traitCollectionDidChange` is called. iOS takes 2 screenshots of light and dark mode for the task switcher when app enters background, which was calling the `traitCollectionDidChange` method, which would set `darkBackground` property when I didn't want to.
- Add another guard to make sure that when `traitCollectionDidChange` is called and app is active, that the current visible view controller is an instance of TimerVC, because it is the only view controller that requires updating the status bar when the style changes. When NoteDetailsVC is visible, status bar should always be white.

Closes #42 